### PR TITLE
Adding missing host parameter to mysqldump

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -327,6 +327,7 @@
 							--disable-keys											\\
 							--extended-insert										\\
 							--hex-blob												\\
+							--host=".escapeshellarg($host)."						\\
 							--lock-tables											\\
 							--quote-names											\\
 							--quick													\\
@@ -368,6 +369,7 @@
 							--disable-keys											\\
 							--extended-insert										\\
 							--hex-blob												\\
+							--host=".escapeshellarg($host)."						\\
 							--lock-tables											\\
 							--quote-names											\\
 							--quick													\\


### PR DESCRIPTION
Adding missing host parameter to mysqldump. Fixes #1 .